### PR TITLE
exercises/pointer-revocation: make arg volatile

### DIFF
--- a/src/exercises/pointer-revocation/temporal-control.c
+++ b/src/exercises/pointer-revocation/temporal-control.c
@@ -30,7 +30,12 @@ fn2(uintptr_t arg)
 
 struct obj {
 	char buf[32];
-	/* Volatile so that the compiler will always reload it */
+	/*
+	 * The following are marked volatile to ensure the compiler doesn't
+	 * constant propagate fn (making aliasing not work) and to ensure
+	 * neither stores to them are optimised away entirely as dead due
+	 * to calling free.
+	 */
 	void (* volatile fn)(uintptr_t);
 	volatile uintptr_t arg;
 };

--- a/src/exercises/pointer-revocation/temporal-control.c
+++ b/src/exercises/pointer-revocation/temporal-control.c
@@ -32,7 +32,7 @@ struct obj {
 	char buf[32];
 	/* Volatile so that the compiler will always reload it */
 	void (* volatile fn)(uintptr_t);
-	uintptr_t arg;
+	volatile uintptr_t arg;
 };
 
 int


### PR DESCRIPTION
Otherwise the compiler can see that we're only using obj1->arg and so won't
necessarily reload it (and might not even store it) as we wish for
demonstration.

Fixes #20.