### PR TITLE
Implement collective suggestions for title and cover page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 <!-- ANCHOR: cover -->
 
-# CHERI Exercises
+# Adversarial CHERI Exercises and Missions
 
-Robert N. M. Watson (University of Cambridge), Brooks Davis (SRI International), Wes Filardo (Microsoft Research), and Jessica Clarke (University of Cambridge)
+Robert N. M. Watson (University of Cambridge), Brooks Davis (SRI
+International), Wes Filardo (Microsoft Research) and Jessica Clarke
+(University of Cambridge)
 
-This repository contains a series of skills development and adversarial exercises for
-[CHERI](http://cheri-cpu.org), specifically aimed at the CHERI-RISC-V
-implementation.
+This repository contains a series of skills development and adversarial
+exercises for [CHERI](http://cheri-cpu.org), specifically aimed at the
+CHERI-RISC-V implementation.
+
+## Acknowledgements
+
+The authors gratefully acknowledge John Baldwin, Reuben Broadfoot, Lawrence
+Esswood, Brett Gutstein, Joe Kiniry, Alex Richardson, Austin Roach, and Daniel
+Zimmerman for their feedback and support in developing these exercises.
 
 <!-- ANCHOR_END: cover -->
 
-# Building
+## Building
 
 Building the book from the Markdown sources requires
 [mdBook](https://github.com/rust-lang/mdBook). Once installed, `mdbook build`

--- a/book.toml
+++ b/book.toml
@@ -3,7 +3,7 @@ authors = ["Jessica Clarke", "Brooks Davis", "Wes Filardo", "Robert N. M. Watson
 language = "en"
 multilingual = false
 src = "src"
-title = "CHERI Exercises"
+title = "Adversarial CHERI Exercises and Missions"
 
 [output.html]
 git-repository-url = "https://github.com/CTSRD-CHERI/cheri-exercises"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-[Cover Page](cover/README.md)
+[Adversarial CHERI Exercises and Missions](cover/README.md)
 - [Introduction](introduction/README.md)
     - [Background reading](introduction/background.md)
     - [Cross compilation and execution](introduction/cross-compilation-execution.md)

--- a/src/introduction/README.md
+++ b/src/introduction/README.md
@@ -13,12 +13,6 @@ These activities supplement existing experience
 with reverse engineering and exploitation on conventional architectures
 and software stacks.
 
-## Acknowledgements
-
-The authors gratefully acknowledge John Baldwin, Reuben Broadfoot, Lawrence
-Esswood, Brett Gutstein, Joe Kiniry, Alex Richardson, Austin Roach, and Daniel
-Zimmerman for their feedback and support in developing these exercises.
-
 ## Skills development exercises
 
 **Skills development exercises** are intended to take 1-2 hours each,


### PR DESCRIPTION
Renames the title and thus cover page to "Adversarial CHERI Exercises and Missions" and hoists acknowledgements from the introduction to the cover.

Whilst here, wrap the cover page contents and make the "Building" heading a sub-heading for the repository README.md.