### PR TITLE
Two starting points for potential kernel missions based on reintroduced vulnerabilities in the FETT pure-capability kernel.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -26,6 +26,6 @@
     - [Exploiting a buffer overflow to manipulate control flow](missions/buffer-overflow-control-flow/README.md)
     - [Exploiting an uninitialized stack frame to manipulate control flow](missions/uninitialized-stack-frame-control-flow/README.md)
     - [Exploiting heap use-after-free to manipulate control flow](missions/use-after-free-control-flow/README.md)
-    - [Exploiting kernel system-call vulnerability to manipulate control flow](kernel-FreeBSD-SA-09\:06.ktimer/README.md)
-    - [Exploiting kernel NFS-server vulnerability to manipulate control flow](kernel-FreeBSD-SA-18\:13.nfs/README.md)
+    - [Exploiting kernel system-call vulnerability to manipulate control flow](kernel-FreeBSD-SA-09%3A06.ktimer/README.md)
+    - [Exploiting kernel NFS-server vulnerability to manipulate control flow](kernel-FreeBSD-SA-18%3A13.nfs/README.md)
 - [Appendix](appendix/README.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -26,6 +26,6 @@
     - [Exploiting a buffer overflow to manipulate control flow](missions/buffer-overflow-control-flow/README.md)
     - [Exploiting an uninitialized stack frame to manipulate control flow](missions/uninitialized-stack-frame-control-flow/README.md)
     - [Exploiting heap use-after-free to manipulate control flow](missions/use-after-free-control-flow/README.md)
-    - [Exploiting kernel system-call vulnerability to manipulate control flow](kernel-FreeBSD-SA-09%3A06.ktimer/README.md)
-    - [Exploiting kernel NFS-server vulnerability to manipulate control flow](kernel-FreeBSD-SA-18%3A13.nfs/README.md)
+    - [Exploiting kernel system-call vulnerability to manipulate control flow](missions/kernel-FreeBSD-SA-09%3A06.ktimer/README.md)
+    - [Exploiting kernel NFS-server vulnerability to manipulate control flow](missions/kernel-FreeBSD-SA-18%3A13.nfs/README.md)
 - [Appendix](appendix/README.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -26,6 +26,6 @@
     - [Exploiting a buffer overflow to manipulate control flow](missions/buffer-overflow-control-flow/README.md)
     - [Exploiting an uninitialized stack frame to manipulate control flow](missions/uninitialized-stack-frame-control-flow/README.md)
     - [Exploiting heap use-after-free to manipulate control flow](missions/use-after-free-control-flow/README.md)
-    - [Exploiting kernel system-call vulnerability to manipulate control flow](kernel-FreeBSD-SA-09:06.ktimer/README.md)
-    - [Exploiting kernel NFS-server vulnerability to manipulate control flow](kernel-FreeBSD-SA-18:13.nfs/README.md)
+    - [Exploiting kernel system-call vulnerability to manipulate control flow](kernel-FreeBSD-SA-09\:06.ktimer/README.md)
+    - [Exploiting kernel NFS-server vulnerability to manipulate control flow](kernel-FreeBSD-SA-18\:13.nfs/README.md)
 - [Appendix](appendix/README.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -26,4 +26,6 @@
     - [Exploiting a buffer overflow to manipulate control flow](missions/buffer-overflow-control-flow/README.md)
     - [Exploiting an uninitialized stack frame to manipulate control flow](missions/uninitialized-stack-frame-control-flow/README.md)
     - [Exploiting heap use-after-free to manipulate control flow](missions/use-after-free-control-flow/README.md)
+    - [Exploiting kernel system-call vulnerability to manipulate control flow](kernel-FreeBSD-SA-09:06.ktimer/README.md)
+    - [Exploiting kernel NFS-server vulnerability to manipulate control flow](kernel-FreeBSD-SA-18:13.nfs/README.md)
 - [Appendix](appendix/README.md)

--- a/src/missions/kernel-FreeBSD-SA-09:06.ktimer/README.md
+++ b/src/missions/kernel-FreeBSD-SA-09:06.ktimer/README.md
@@ -10,7 +10,7 @@ More information on the timer system-call interface can be found in the [`timer_
 
 Successful completion of this mission requires demonstrating that the kernel function `flag_captured(9)` has executed with the integer argument `0xfe77c0de` using one of the `ktimer(2)` system calls triggered as an unprivileged (non-root) user.
 Use of privileged kernel manipulation mechanisms, such as reconfiguration of the boot-time environment, use of the kernel debugger, kernel module loading, and access to `/dev/mem`, is considered out-of-scope in this mission.
-If `flag_captured(9)` is called, the sysctl `security.flags_captured` counter will be incremented.
+If `flag_captured(9)` is called, the sysctl `security.kernel_flags_captured` counter will be incremented.
 This corresponds to a partially successful exploit.
-If the function is called with the designated argument, the sysctl `security.flags_captured_key` counter will be incremented.
+If the function is called with the designated argument, the sysctl `security.kernel_flags_captured_key` counter will be incremented.
 This corresponds to a fully successful exploit.

--- a/src/missions/kernel-FreeBSD-SA-09:06.ktimer/README.md
+++ b/src/missions/kernel-FreeBSD-SA-09:06.ktimer/README.md
@@ -1,6 +1,6 @@
 # Exploit vulnerability FreeBSD-SA-09:06.ktimer: kernel buffer overflow
 
-This mission depends on the pure-capability CheriBSD FETT kernel included in FETT CHERI-RISC-V Mission 2 (kernel spatial memory safety).
+This mission depends on the pure-capability CheriBSD FETT kernel included in FETT CHERI-RISC-V Release 2 (kernel spatial memory safety).
 
 The objective of this mission is to demonstrate arbitrary code execution in a pure-capability kernel.
 This must be achieved via a reintroduced past FreeBSD security vulnerability, [FreeBSD-SA-09:06.ktimer](https://www.freebsd.org/security/advisories/FreeBSD-SA-09:06.ktimer.asc).

--- a/src/missions/kernel-FreeBSD-SA-09:06.ktimer/README.md
+++ b/src/missions/kernel-FreeBSD-SA-09:06.ktimer/README.md
@@ -6,6 +6,7 @@ The objective of this mission is to demonstrate arbitrary code execution in a pu
 This must be achieved via a reintroduced past FreeBSD security vulnerability, [FreeBSD-SA-09:06.ktimer](https://www.freebsd.org/security/advisories/FreeBSD-SA-09:06.ktimer.asc).
 We have reintroduced this via change [69bb6a5e55fc94dd7338e22492971edbf55f8393](https://github.com/CTSRD-CHERI/cheribsd/commit/69bb6a5e55fc94dd7338e22492971edbf55f8393) in the pure-capability kernel branch of the CheriBSD repository.
 In this vulnerability, an integer system-call argument is not properly bounds checked, allowing an out-of-bounds access that on a vanilla non-CHERI system is exploitable to gain kernel privilege.
+More information on the timer system-call interface can be found in the [`timer_settime(2)`](https://www.freebsd.org/cgi/man.cgi?query=timer_settime&sektion=2) and related man pages.
 
 Successful completion of this mission requires demonstrating that the kernel function `flag_captured(9)` has executed with the integer argument `0xfe77c0de` using one of the `ktimer(2)` system calls triggered as an unprivileged (non-root) user.
 Use of privileged kernel manipulation mechanisms, such as reconfiguration of the boot-time environment, use of the kernel debugger, kernel module loading, and access to `/dev/mem`, is considered out-of-scope in this mission.

--- a/src/missions/kernel-FreeBSD-SA-09:06.ktimer/README.md
+++ b/src/missions/kernel-FreeBSD-SA-09:06.ktimer/README.md
@@ -1,0 +1,15 @@
+# Exploit vulnerability FreeBSD-SA-09:06.ktimer: kernel buffer overflow
+
+This mission depends on the pure-capability CheriBSD FETT kernel included in FETT CHERI-RISC-V Mission 2 (kernel spatial memory safety).
+
+The objective of this mission is to demonstrate arbitrary code execution in a pure-capability kernel.
+This must be achieved via a reintroduced past FreeBSD security vulnerability, [FreeBSD-SA-09:06.ktimer](https://www.freebsd.org/security/advisories/FreeBSD-SA-09:06.ktimer.asc).
+We have reintroduced this via change [69bb6a5e55fc94dd7338e22492971edbf55f8393](https://github.com/CTSRD-CHERI/cheribsd/commit/69bb6a5e55fc94dd7338e22492971edbf55f8393) in the pure-capability kernel branch of the CheriBSD repository.
+In this vulnerability, an integer system-call argument is not properly bounds checked, allowing an out-of-bounds access that on a vanilla non-CHERI system is exploitable to gain kernel privilege.
+
+Successful completion of this mission requires demonstrating that the kernel function `flag_captured(9)` has executed with the integer argument `0xfe77c0de` using one of the `ktimer(2)` system calls triggered as an unprivileged (non-root) user.
+Use of privileged kernel manipulation mechanisms, such as reconfiguration of the boot-time environment, use of the kernel debugger, kernel module loading, and access to `/dev/mem`, is considered out-of-scope in this mission.
+If `flag_captured(9)` is called, the sysctl `security.flags_captured` counter will be incremented.
+This corresponds to a partially successful exploit.
+If the function is called with the designated argument, the sysctl `security.flags_captured_key` counter will be incremented.
+This corresponds to a fully successful exploit.

--- a/src/missions/kernel-FreeBSD-SA-18:13.nfs/README.md
+++ b/src/missions/kernel-FreeBSD-SA-18:13.nfs/README.md
@@ -1,0 +1,15 @@
+# Exploit vulnerability FreeBSD-SA-18:13.nfs: out-of-bounds access
+
+This mission depends on the pure-capability CheriBSD FETT kernel included in FETT CHERI-RISC-V Mission 2 (kernel spatial memory safety).
+
+The objective of this mission is to demonstrate arbitrary code execution in a pure-capability kernel.
+This must be achieved via a reintroduced past FreeBSD security vulnerability, [FreeBSD-SA-18:13.nfs](FreeBSD-SA-18:13.nfs).
+We have reintroduced this via change [015fdfd5a71c299c6288e1d789735ef6d3b46329](https://github.com/CTSRD-CHERI/cheribsd/commit/015fdfd5a71c299c6288e1d789735ef6d3b46329) in the pure-capability kernel branch of the CheriBSD repository.
+In this vulnerability, an out-of-bounds access is performed during received NFS packet processing, which is exploitable on a vanilla non-CHERI system to gain kernel privilege.
+
+Successful completion of this mission requires demonstrating that the kernel function `flag_captured(9)` has executed with the integer argument `0xfe77c0de` using the use of an NFS packet exploiting this vulnerability.
+Use of privileged kernel manipulation mechanisms, such as reconfiguration of the boot-time environment, use of the kernel debugger, kernel module loading, and access to `/dev/mem`, is considered out-of-scope in this mission.
+If `flag_captured(9)` is called, the sysctl `security.flags_captured` counter will be incremented.
+This corresponds to a partially successful exploit.
+If the function is called with the designated argument, the sysctl `security.flags_captured_key` counter will be incremented.
+This corresponds to a fully successful exploit.

--- a/src/missions/kernel-FreeBSD-SA-18:13.nfs/README.md
+++ b/src/missions/kernel-FreeBSD-SA-18:13.nfs/README.md
@@ -6,6 +6,7 @@ The objective of this mission is to demonstrate arbitrary code execution in a pu
 This must be achieved via a reintroduced past FreeBSD security vulnerability, [FreeBSD-SA-18:13.nfs](FreeBSD-SA-18:13.nfs).
 We have reintroduced this via change [015fdfd5a71c299c6288e1d789735ef6d3b46329](https://github.com/CTSRD-CHERI/cheribsd/commit/015fdfd5a71c299c6288e1d789735ef6d3b46329) in the pure-capability kernel branch of the CheriBSD repository.
 In this vulnerability, an out-of-bounds access is performed during received NFS packet processing, which is exploitable on a vanilla non-CHERI system to gain kernel privilege.
+More information on the NFSv4 packet format may be found in [RFC7530](https://tools.ietf.org/html/rfc7530).
 
 Successful completion of this mission requires demonstrating that the kernel function `flag_captured(9)` has executed with the integer argument `0xfe77c0de` using the use of an NFS packet exploiting this vulnerability.
 Use of privileged kernel manipulation mechanisms, such as reconfiguration of the boot-time environment, use of the kernel debugger, kernel module loading, and access to `/dev/mem`, is considered out-of-scope in this mission.

--- a/src/missions/kernel-FreeBSD-SA-18:13.nfs/README.md
+++ b/src/missions/kernel-FreeBSD-SA-18:13.nfs/README.md
@@ -1,6 +1,6 @@
 # Exploit vulnerability FreeBSD-SA-18:13.nfs: out-of-bounds access
 
-This mission depends on the pure-capability CheriBSD FETT kernel included in FETT CHERI-RISC-V Mission 2 (kernel spatial memory safety).
+This mission depends on the pure-capability CheriBSD FETT kernel included in FETT CHERI-RISC-V Release 2 (kernel spatial memory safety).
 
 The objective of this mission is to demonstrate arbitrary code execution in a pure-capability kernel.
 This must be achieved via a reintroduced past FreeBSD security vulnerability, [FreeBSD-SA-18:13.nfs](FreeBSD-SA-18:13.nfs).


### PR DESCRIPTION
Per @austinhroach's suggestion, I've created two text wrappers around the two reintroduced vulnerabilities, patches, etc., we shipped in the FETT Release 2 pure-capability kernel. I've attempted to adequately contextualise them, but it could be that, for example, they would benefit from further pointers into kernel source, man pages (e.g., ktimers?), etc.