### PR TITLE
Make references to ISAs more generic.

### DIFF
--- a/src/introduction/README.md
+++ b/src/introduction/README.md
@@ -34,7 +34,7 @@ These exercises take for granted a strong existing understanding of:
 ## Focused adversarial missions
 **Focused adversarial missions** are intended to take
 1-3 days, and ask you to exploit, first on an unmodified ISA, and
-then on a CHERI enabled ISA, documented vulnerabilities in simple "potted"
+then on a CHERI-enabled ISA, documented vulnerabilities in simple "potted"
 C/C++-language programs provided by the CHERI team. These missions
 engage you more specifically in exploitation, and CHERI's
 security objectives and mechanisms.

--- a/src/introduction/README.md
+++ b/src/introduction/README.md
@@ -2,10 +2,12 @@
 
 This set of exercises and adversarial missions is intended to:
 
-- Build a baseline skillset with RISC-V and CHERI-RISC-V, as well as awareness
+- Build a baseline skill set with unmodified instruction set
+  architectures (ISAs) such as ARMv8 and RISC-V as well as the same
+  baseline ISAs with CHERI extensions, as well as awareness
   of some of the dynamics of CHERI-enabled software, through skills development
   exercises.
-- Develop adversarial experience with CHERI-RISC-V performing basic
+- Develop adversarial experience with CHERI enabled ISAs performing basic
   investigation around gradations of CHERI feature deployment through focused
   adversarial missions.
 
@@ -16,25 +18,25 @@ and software stacks.
 ## Skills development exercises
 
 **Skills development exercises** are intended to take 1-2 hours each,
-and ask you to build and perform minor modifications to simple
-RISC-V and CHERI-RISC-V C/C++ programs. These exercises
-facilitate building skills such as compiling, executing,
-and debugging RISC-V and CHERI-RISC-V programs, as well as to build basic
-understanding of CHERI C/C++ properties. We highlight some key edge
-cases in CHERI, including the effects of bounds imprecision, subobject
-bounds, weaker temporal safety, and C type confusion.
+and ask you to build and perform minor modifications to simple C/C++
+programs. These exercises facilitate building skills such as
+compiling, executing, and debugging programs with both CHERI enabled
+and default ISAs, as well as to build basic understanding of CHERI
+C/C++ properties. We highlight some key edge cases in CHERI, including
+the effects of bounds imprecision, subobject bounds, weaker temporal
+safety, and C type confusion.
 
 These exercises take for granted a strong existing understanding of:
 - The C/C++ languages
 - UNIX program compilation, execution, and debugging
-- RISC ISAs and binary structures/reverse engineering (e.g., on MIPS or ARMv8)
+- ARMv8 and/or RISC ISAs as well as binary structures/reverse engineering
 
 ## Focused adversarial missions
 **Focused adversarial missions** are intended to take
-1-3 days, and ask you to exploit, first on RISC-V, and
-then on CHERI-RISC-V, documented vulnerabilities in simple "potted"
-C/C++-language programs provided by the CHERI-RISC-V team. These missions
-engage you more specifically in RISC-V exploitation, and CHERI's
+1-3 days, and ask you to exploit, first on an unmodified ISA, and
+then on a CHERI enabled ISA, documented vulnerabilities in simple "potted"
+C/C++-language programs provided by the CHERI team. These missions
+engage you more specifically in exploitation, and CHERI's
 security objectives and mechanisms.
 
 **These take for granted good existing experience with
@@ -42,14 +44,14 @@ memory-safety-related attack techniques, such as buffer overflows,
 integer-pointer type confusion, Return-Oriented Programming (ROP), and
 Jump-Oriented Programming (JOP).**
 
-Successful exploitation of RISC-V variants depends only upon
-widely published understanding and techniques (e.g., buffer overflows
-combined with ROP). For those familiar with conventional low-level
-attack techniques, this will also act as a warm-up exercise on the
-baseline RISC-V architecture and expand experience with RISC-V reverse
+Successful exploitation of non CHERI enabled variants depends only
+upon widely published understanding and techniques (e.g., buffer
+overflows combined with ROP). For those familiar with conventional
+low-level attack techniques, this will also act as a warm-up exercise
+on the baseline architecture and expand experience with reverse
 engineering and exploitation.
 
-The CHERI-RISC-V team has confirmed exploitability for the RISC-V binary
-in advance.  We strongly recommend exploiting the RISC-V version of the code
-first, as a starting point for understanding potential CHERI-RISC-V
-exploitability.
+The CHERI team has confirmed exploitability for the non CHERI enabled
+binaries in advance.  We strongly recommend exploiting the non CHERI
+enabled version of the code first, as a starting point for
+understanding potential CHERI-RISC-V exploitability.

--- a/src/introduction/README.md
+++ b/src/introduction/README.md
@@ -54,4 +54,4 @@ engineering and exploitation.
 The CHERI team has confirmed exploitability for the non CHERI enabled
 binaries in advance.  We strongly recommend exploiting the non CHERI
 enabled version of the code first, as a starting point for
-understanding potential CHERI-RISC-V exploitability.
+understanding potential exploitability of the CHERI version.

--- a/src/introduction/README.md
+++ b/src/introduction/README.md
@@ -3,7 +3,7 @@
 This set of exercises and adversarial missions is intended to:
 
 - Build a baseline skill set with unmodified instruction set
-  architectures (ISAs) such as ARMv8 and RISC-V as well as the same
+  architectures (ISAs) such as ARMv8 and RISC-V and the same
   baseline ISAs with CHERI extensions, as well as awareness
   of some of the dynamics of CHERI-enabled software, through skills development
   exercises.


### PR DESCRIPTION
This is a first cut at how I'd like to expand the exercises to properly cover morello as well as RISC-V.