### PR TITLE
Add mdbook linkcheck output plugin

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -8,3 +8,5 @@ title = "Adversarial CHERI Exercises and Missions"
 [output.html]
 git-repository-url = "https://github.com/CTSRD-CHERI/cheri-exercises"
 site-url = "/cheri-exercises/"
+
+[output.linkcheck]


### PR DESCRIPTION
`mdbook` is generally not very helpful in terms of detecting semantic issues.  The lintcheck plugin helps.