### PR TITLE
Emulated TLS no longer required for emulated purecap code on Morello.

### DIFF
--- a/tools/ccc
+++ b/tools/ccc
@@ -76,11 +76,11 @@ aarch64)
 	;;
 morello-hybrid)
 	cheri_sdk_name=morello-sdk
-	arch_flags="-target aarch64-unknown-freebsd -march=morello+a64c"
+	arch_flags="-target aarch64-unknown-freebsd -march=morello+a64c -Xclang -morello-vararg=new"
 	;;
 morello-purecap)
 	cheri_sdk_name=morello-sdk
-	arch_flags="-target aarch64-unknown-freebsd -march=morello+c64 -mabi=purecap -femulated-tls"
+	arch_flags="-target aarch64-unknown-freebsd -march=morello+c64 -mabi=purecap -Xclang -morello-vararg=new"
 	;;
 riscv64)
 	arch_flags="-target riscv64-unknown-freebsd -march=rv64gc -mabi=lp64d -mno-relax"


### PR DESCRIPTION
With the recent shift to a proper thread-local storage ABI for Morello purecap code, `ccc` no longer needs to request emulated TLS.